### PR TITLE
Refactor the tiles

### DIFF
--- a/src/tiles/EmptyTile.java
+++ b/src/tiles/EmptyTile.java
@@ -1,8 +1,5 @@
 package tiles;
 
-import main.Collectable;
-import main.Inventory;
-
 /**
  * An empty tile of the game where no collectable can be picked up.
  */
@@ -15,21 +12,5 @@ public class EmptyTile extends Tile {
      */
     public EmptyTile(int id, String name) {
         super(id, name);
-    }
-
-    /**
-     * Clones the collectable of the field and calls its collect method,
-     * that'll eventually put the new collectable into the inventory.
-     * Since nothing can be picked up from here, this method does nothing.
-     * @param inv The clone of the Collectable has to be stored in this inventory.
-     */
-    public void collectItem(Inventory inv) {}
-
-    /**
-     * Returns the collectable that can be picked up from this tile.
-     * @return Null, since nothing can be picked up from here.
-     */
-    public Collectable getCollectableItem() {
-        return null;
     }
 }

--- a/src/tiles/InfectedLaboratory.java
+++ b/src/tiles/InfectedLaboratory.java
@@ -28,6 +28,7 @@ public class InfectedLaboratory extends Laboratory {
      * Infects the player that moved here with the agent of the tile.
      * @param player The player to be added.
      */
+    @Override
     public void addVirologist(Virologist player) {
         players.add(player);
         infectable.use(null, player);

--- a/src/tiles/Laboratory.java
+++ b/src/tiles/Laboratory.java
@@ -1,19 +1,11 @@
 package tiles;
 
-import main.Collectable;
 import main.GeneticCode;
-import main.Inventory;
 
 /**
  * A laboratory tile where virologists can learn genetic codes.
  */
 public class Laboratory extends Tile {
-
-    /**
-     * The code that can be learnt here.
-     */
-    protected final GeneticCode code;
-
     /**
      * Constructor
      * Sets the code to be the one received as a parameter.
@@ -22,25 +14,6 @@ public class Laboratory extends Tile {
      * @param gc The GeneticCode that can be learnt here
      */
     public Laboratory(int id, String name, GeneticCode gc) {
-        super(id, name);
-        code = gc;
-    }
-
-    /**
-     * Clones th collectable of the field and calls its collect method,
-     * that'll eventually put the new collectable into the inventory.
-     * In this case, it clones the code and calls its collect method.
-     * @param inv The clone of the Collectable has to be stored in this inventory.
-     */
-    public void collectItem(Inventory inv) {
-        code.cloneCollectable().collect(inv);
-    }
-
-    /**
-     * Returns the collectable that can be picked up from this tile.
-     * @return The genetic code that can be learnt here.
-     */
-    public Collectable getCollectableItem() {
-        return code;
+        super(id, name, gc);
     }
 }

--- a/src/tiles/Safehouse.java
+++ b/src/tiles/Safehouse.java
@@ -1,21 +1,11 @@
 package tiles;
 
-import equipments.*;
-import main.Collectable;
-import main.Inventory;
-
-import java.util.Random;
+import equipments.Equipment;
 
 /**
  * A safehouse tile where players can pick up equipments.
  */
 public class Safehouse extends Tile {
-
-    /**
-     * The equipment that can be picked up here.
-     */
-    private final Equipment equipment;
-
     /**
      * Constructor
      * Sets to collectable equipment to be the one received as a paramter.
@@ -24,25 +14,6 @@ public class Safehouse extends Tile {
      * @param eq Equipment on the tile.
      */
     public Safehouse(int id, String name, Equipment eq) {
-        super(id, name);
-        equipment = eq;
-    }
-
-    /**
-     * Clones the collectable of the field and calls its collect method,
-     * that'll eventually put the new collectable into the inventory.
-     * In this case, it clones the equipment and calls its collect method.
-     * @param inv The clone of the Collectable has to be stored in this inventory.
-     */
-    public void collectItem(Inventory inv) {
-        equipment.cloneCollectable().collect(inv);
-    }
-
-    /**
-     * Returns the collectable that can be picked up from this tile.
-     * @return The equipment that can be picked up here.
-     */
-    public Collectable getCollectableItem() {
-        return equipment;
+        super(id, name, eq);
     }
 }

--- a/src/tiles/Tile.java
+++ b/src/tiles/Tile.java
@@ -34,6 +34,11 @@ public abstract class Tile {
     protected final ArrayList<Virologist> players;
 
     /**
+     * The collectable that can be picked up from this tile.
+     */
+    protected Collectable collectable = null;
+
+    /**
      * Constructor
      * @param id Unique identifier of the tile.
      * @param name Name of the tile.
@@ -43,6 +48,17 @@ public abstract class Tile {
         this.name = name;
         players = new ArrayList<>();
         neighbours = new ArrayList<>();
+    }
+
+    /**
+     * Constructor that also sets the Collectable
+     * @param id Unique identifier of the tile.
+     * @param name Name of the tile.
+     * @param c The collectable that can be picked up from this tile
+     */
+    public Tile(int id, String name, Collectable c) {
+        this(id, name);
+        collectable = c;
     }
 
     /**
@@ -60,13 +76,19 @@ public abstract class Tile {
      * that'll eventually put the new collectable into the inventory.
      * @param inv The clone of the Collectable has to be stored in this inventory.
      */
-    public abstract void collectItem(Inventory inv);
+    public void collectItem(Inventory inv) {
+        if (collectable != null) {
+            collectable.cloneCollectable().collect(inv);
+        }
+    }
 
     /**
      * Getter for the collectable of the field.
      * @return Collectable of the field.
      */
-    public abstract Collectable getCollectableItem();
+    public Collectable getCollectableItem() {
+        return collectable;
+    }
 
     /**
      * Adds the virologist to the players list.

--- a/src/tiles/Warehouse.java
+++ b/src/tiles/Warehouse.java
@@ -1,22 +1,11 @@
 package tiles;
 
-import main.Collectable;
-import main.Inventory;
 import main.Resource;
-import main.ResourceType;
-
-import java.util.ArrayList;
 
 /**
  * Warehouse field where virologists can pick up resources.
  */
 public class Warehouse extends Tile {
-
-    /**
-     * The resource that can be picked up here.
-     */
-    private Resource collectable;
-
     /**
      * Constructor that takes resource from parameter.
      * @param id Unique identifier of the tile.
@@ -24,30 +13,8 @@ public class Warehouse extends Tile {
      * @param collectable The resource that can be picked up from this tile
      */
     public Warehouse(int id, String name, Resource collectable) {
-        super(id, name);
-        this.collectable = collectable;
+        super(id, name, collectable);
     }
-
-    /**
-     * Clones the collectable of the field and calls its collect method,
-     * that'll eventually put the new collectable into the inventory.
-     * In this case, it clones the resource and calls its collect method.
-     * @param inv The clone of the Collectable has to be stored in this inventory.
-     */
-    public void collectItem(Inventory inv) {
-        if (collectable != null) {
-            collectable.cloneCollectable().collect(inv);
-        }
-    }
-
-    /**
-     * Returns the collectable that can be picked up from this tile.
-     * @return The resource that can be picked up here.
-     */
-    public Collectable getCollectableItem() {
-        return collectable;
-    }
-
 
     /**
      * A method to destroy the collectable of the tile.


### PR DESCRIPTION
Dani ötlete alapján az ősosztálynak van Collectable-je, nem a mezőknek egyenként. Igazából ezek után a Tile-nak nem is kéne absztrakt osztálynak lennie, sőt a Labor, Safehouse és EmptyTile osztályok gyakorlatilag feleslegesek, de szerintem ezek maradjanak, grafikusnál még lesz értelme (igazából a ConsoleView is használja egy helyen az alapértelmezett toStringet, és abból veszi ki az osztálynevet).
Vagy emlékszik valaki arra, hogy ez eddig mért nem így volt csinálva? Lehet elront ez valamit, csak nem gondoltam bele eléggé.

Osztálydiagrammot (meg az összes függvényleírást) is elég rendesen átrendezi ez, nem tudom kell-e még azt frissíteni.